### PR TITLE
Define BV

### DIFF
--- a/src/Temperature_LM75_Derived.h
+++ b/src/Temperature_LM75_Derived.h
@@ -2,6 +2,9 @@
 #define TEMPERATURE_LM75_DERIVED_H
 
 #include <Wire.h>
+#ifndef _BV
+#define _BV(b) (1UL << (b))
+#endif
 
 class Temperature_LM75_Derived {
 public:


### PR DESCRIPTION
I tried to use this library on arduino-nrf5 but the it does not has `_BV` and will not support.
(I created PR for arduino-ntf5 but it was rejected. https://github.com/sandeepmistry/arduino-nRF5/pull/349)
Could you define `_BV` in this library?
If you prefer to use `bit` instead of `_BV`, I close this PR and create another PR with using the following commit.
https://github.com/asukiaaa/Temperature_LM75_Derived/commit/391aec850ee2b02ecf6518ffb96b69091ff066f5

Thank you for sharing an useful project.