### PR TITLE
Fixed SENSOR_ALERT_PIN being set to output

### DIFF
--- a/examples/Thermostat/Thermostat.ino
+++ b/examples/Thermostat/Thermostat.ino
@@ -40,8 +40,7 @@ void setup() {
 
 #ifdef SENSOR_ALERT_PULLUP
   // Enable the internal pullup
-  pinMode(SENSOR_ALERT_PIN, OUTPUT);
-  digitalWrite(SENSOR_ALERT_PIN, HIGH);
+  pinMode(SENSOR_ALERT_PIN, INPUT_PULLUP);
 #endif
 
   Wire.begin();


### PR DESCRIPTION
The thermostat example sets the sensor alert pin to output-high, meaning it'll never alert. This sets it to `INPUT_PULLUP` which is equivalent to
```C
pinMode(pin, INPUT);
digitalWrite(pin, HIGH);
```
or
```C
DDRx |= (1 << Pxy);
PORTx |= (1 << Pxy);
```