### PR TITLE
Added support for one shot on OnSemi NCT sensors

### DIFF
--- a/doc/Sensors.md
+++ b/doc/Sensors.md
@@ -13,7 +13,7 @@ NXP | [LM75A](https://www.nxp.com/docs/en/data-sheet/LM75A.pdf) | SOIC8<br>TSSOP
 NXP | [LM75B](https://www.nxp.com/docs/en/data-sheet/LM75B.pdf) | SOIC8<br>TSSOP8<br>XSON8U<br>HWSON8 | 2.8V | 5.5V | 11b | ±2°C | | `NXP_LM75B` |
 NXP | [PCT2075](https://www.nxp.com/docs/en/data-sheet/PCT2075.pdf) | SOIC8<br>TSSOP8<br>HWSON8<br>TSOP6 | 2.7V | 5.5V | 11b | ±1°C | | `NXP_PCT2075` | <sup>10</sup>
 NXP | [SE95](https://www.nxp.com/docs/en/data-sheet/SE95.pdf) | SOIC8<br>TSSOP8 | 2.8V | 5.5V | 13b | ±1°C | | `NXP_SE95` |
-ON Semiconductor | [NCT75](https://www.onsemi.com/pub/Collateral/NCT75-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `ON_NCT75`<br>`ON_NCT_OS`|
+ON Semiconductor | [NCT75](https://www.onsemi.com/pub/Collateral/NCT75-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `ON_NCT75` |
 STMicroelectronics | [STCN75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stcn75.html) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9b | ±0.5°C | | `Generic_LM75` |
 STMicroelectronics | [STLM75](http://www.st.com/content/ccc/resource/technical/document/datasheet/22/c6/56/13/dd/59/4b/43/CD00153511.pdf/files/CD00153511.pdf/jcr:content/translations/en.CD00153511.pdf) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9b | ±2°C | | `ST_STLM75` |
 STMicroelectronics | [STTS75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stts75.html) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9-12b | ±0.5°C | ✓ | `ST_STTS75` |
@@ -48,7 +48,7 @@ Maxim Integrated | [MAX6625](https://datasheets.maximintegrated.com/en/ds/MAX662
 Maxim Integrated | [MAX6626](https://datasheets.maximintegrated.com/en/ds/MAX6625-MAX6626.pdf) | TDFN6 | 3.0V | 5.5V | 12b | ±1°C | | `Generic_LM75_12Bit` |
 Microchip | [AT30TS750A](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8855-DTS-AT30TS750A-Datasheet.pdf) | SOIC8<br>MSOP8<br>UDFN8 | 1.7V | 5.5V | 9-12b | ±0.5°C | ✓ | `Microchip_AT30TS750A` | <sup>7</sup>
 NXP | [PCT2202](https://www.nxp.com/docs/en/data-sheet/PCT2202.pdf) | WLCSP6 | 1.65V | 1.95V | 12-13b <sup>1</sup> | ±0.5°C | | `Generic_LM75_12Bit` |
-ON Semiconductor | [NCT375](http://www.onsemi.com/pub/Collateral/NCT375-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `Generic_LM75_12Bit`<br>`ON_NCT_OS` |
+ON Semiconductor | [NCT375](http://www.onsemi.com/pub/Collateral/NCT375-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `ON_NCT375` |
 STMicroelectronics | [STDS75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stds75.html) | TSSOP8 | 2.7V | 5.5V | 9-12b | ±0.5°C | | `Generic_LM75_9_to_12Bit` |
 Texas&nbsp;Instruments | [TMP112](http://www.ti.com/lit/ds/symlink/tmp112.pdf) | SOT563 | 1.4V | 3.6V | 9-13b <sup>1</sup> | ±0.5°C | ✓ | `TI_TMP112` | <sup>2</sup>&nbsp;<sup>3</sup>&nbsp;<sup>4</sup>
 
@@ -87,7 +87,7 @@ There are many sensors based on or similar to the LM75 register layout and proto
 
 <sup>10</sup> Sensor supports setting the conversion rate through a separate register. This feature is not currently supported.
 
-<sup>11</sup> Sensor supports one-shot conversion, but incompatibly with the TMP75 implementation. Check the `OnSemiOneShotMode` example on how to use this.
+<sup>11</sup> Sensor supports one-shot conversion, but incompatibly with the TMP75 implementation. Check the `OnSemiOneShotMode` example for a detailed example of how to use this.
 ---
 
 <sup>a</sup> SOT23 pinout is SCL, GND, ALERT (or ADD<sub>1</sub>), V<sub>DD</sub>, ADD<sub>0</sub> (or unpopulated for -5 variant), SDA.

--- a/doc/Sensors.md
+++ b/doc/Sensors.md
@@ -87,7 +87,7 @@ There are many sensors based on or similar to the LM75 register layout and proto
 
 <sup>10</sup> Sensor supports setting the conversion rate through a separate register. This feature is not currently supported.
 
-<sup>11</sup> Sensor supports one-shot conversion, but incompatibly with the TMP75 implementation. Check special example on how to use this.
+<sup>11</sup> Sensor supports one-shot conversion, but incompatibly with the TMP75 implementation. Check the `OnSemiOneShotMode` example on how to use this.
 ---
 
 <sup>a</sup> SOT23 pinout is SCL, GND, ALERT (or ADD<sub>1</sub>), V<sub>DD</sub>, ADD<sub>0</sub> (or unpopulated for -5 variant), SDA.

--- a/doc/Sensors.md
+++ b/doc/Sensors.md
@@ -13,7 +13,7 @@ NXP | [LM75A](https://www.nxp.com/docs/en/data-sheet/LM75A.pdf) | SOIC8<br>TSSOP
 NXP | [LM75B](https://www.nxp.com/docs/en/data-sheet/LM75B.pdf) | SOIC8<br>TSSOP8<br>XSON8U<br>HWSON8 | 2.8V | 5.5V | 11b | ±2°C | | `NXP_LM75B` |
 NXP | [PCT2075](https://www.nxp.com/docs/en/data-sheet/PCT2075.pdf) | SOIC8<br>TSSOP8<br>HWSON8<br>TSOP6 | 2.7V | 5.5V | 11b | ±1°C | | `NXP_PCT2075` | <sup>10</sup>
 NXP | [SE95](https://www.nxp.com/docs/en/data-sheet/SE95.pdf) | SOIC8<br>TSSOP8 | 2.8V | 5.5V | 13b | ±1°C | | `NXP_SE95` |
-ON Semiconductor | [NCT75](https://www.onsemi.com/pub/Collateral/NCT75-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>6</sup> | `ON_NCT75` |
+ON Semiconductor | [NCT75](https://www.onsemi.com/pub/Collateral/NCT75-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `ON_NCT75`<br>`ON_NCT_OS`|
 STMicroelectronics | [STCN75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stcn75.html) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9b | ±0.5°C | | `Generic_LM75` |
 STMicroelectronics | [STLM75](http://www.st.com/content/ccc/resource/technical/document/datasheet/22/c6/56/13/dd/59/4b/43/CD00153511.pdf/files/CD00153511.pdf/jcr:content/translations/en.CD00153511.pdf) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9b | ±2°C | | `ST_STLM75` |
 STMicroelectronics | [STTS75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stts75.html) | SOIC8<br>TSSOP8 | 2.7V | 5.5V | 9-12b | ±0.5°C | ✓ | `ST_STTS75` |
@@ -48,7 +48,7 @@ Maxim Integrated | [MAX6625](https://datasheets.maximintegrated.com/en/ds/MAX662
 Maxim Integrated | [MAX6626](https://datasheets.maximintegrated.com/en/ds/MAX6625-MAX6626.pdf) | TDFN6 | 3.0V | 5.5V | 12b | ±1°C | | `Generic_LM75_12Bit` |
 Microchip | [AT30TS750A](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8855-DTS-AT30TS750A-Datasheet.pdf) | SOIC8<br>MSOP8<br>UDFN8 | 1.7V | 5.5V | 9-12b | ±0.5°C | ✓ | `Microchip_AT30TS750A` | <sup>7</sup>
 NXP | [PCT2202](https://www.nxp.com/docs/en/data-sheet/PCT2202.pdf) | WLCSP6 | 1.65V | 1.95V | 12-13b <sup>1</sup> | ±0.5°C | | `Generic_LM75_12Bit` |
-ON Semiconductor | [NCT375](http://www.onsemi.com/pub/Collateral/NCT375-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>6</sup> | `Generic_LM75_12Bit` |
+ON Semiconductor | [NCT375](http://www.onsemi.com/pub/Collateral/NCT375-D.PDF) | SOIC8<br>DFN8<br>Micro8™ | 3.0V | 5.5V | 12b | ±1°C | <sup>11</sup> | `Generic_LM75_12Bit`<br>`ON_NCT_OS` |
 STMicroelectronics | [STDS75](http://www.st.com/content/st_com/en/products/mems-and-sensors/temperature-sensors/stds75.html) | TSSOP8 | 2.7V | 5.5V | 9-12b | ±0.5°C | | `Generic_LM75_9_to_12Bit` |
 Texas&nbsp;Instruments | [TMP112](http://www.ti.com/lit/ds/symlink/tmp112.pdf) | SOT563 | 1.4V | 3.6V | 9-13b <sup>1</sup> | ±0.5°C | ✓ | `TI_TMP112` | <sup>2</sup>&nbsp;<sup>3</sup>&nbsp;<sup>4</sup>
 
@@ -87,6 +87,7 @@ There are many sensors based on or similar to the LM75 register layout and proto
 
 <sup>10</sup> Sensor supports setting the conversion rate through a separate register. This feature is not currently supported.
 
+<sup>11</sup> Sensor supports one-shot conversion, but incompatibly with the TMP75 implementation. Check special example on how to use this.
 ---
 
 <sup>a</sup> SOT23 pinout is SCL, GND, ALERT (or ADD<sub>1</sub>), V<sub>DD</sub>, ADD<sub>0</sub> (or unpopulated for -5 variant), SDA.

--- a/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
+++ b/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
@@ -1,0 +1,53 @@
+/*
+This example is specific to the NCT75 sensor from OnSemi, as it uses a non-standard
+one-shot method
+
+Shut down the sensor, and use one-shot conversion to request a single immediate
+temperature conversion.
+
+In order to save power, LM75-derived temperature sensors can be placed in
+"shutdown" mode where they stop making regular temperature conversions. Some
+sensors support a "one-shot" mode to request a single temperature conversion
+from an otherwise shutdown sensor. This can be used for two purposes:
+
+  * To conserve (a lot of) power by making very infrequent temperature
+    conversions, such as every few minutes.
+
+  * To convert more frequently than the usually-supported temperature
+    conversion rates allow on very fast sensors (such as TMP102/TMP112).
+*/
+
+#include <Temperature_LM75_Derived.h>
+
+OnSemi_OneShot temperature;
+
+void setup() {
+  while(!Serial) {}
+  
+  Serial.begin(9600);
+
+  Wire.begin();
+
+  temperature.enableOneShotMode();
+}
+
+void loop() {
+  Serial.println("Starting temperature conversion...");
+  temperature.startOneShotConversion();
+
+  Serial.println("Waiting for conversion to be ready...");
+
+  /* 
+  The NCT75 doesn't offer any way to check when a conversion is done
+  The datasheet instead lists the typical conversion time to be 48.5 ms.
+  As it doesn't list the max conversion time, we wait ~2x the typical time
+  */
+  delay(100); 
+  
+  Serial.print("Temperature is: ");
+  Serial.print(temperature.readTemperatureC());
+  Serial.println(" C!");
+  Serial.println();
+
+  delay(250);
+}

--- a/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
+++ b/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
@@ -19,11 +19,11 @@ from an otherwise shutdown sensor. This can be used for two purposes:
 
 #include <Temperature_LM75_Derived.h>
 
-OnSemi_OneShot temperature;
+ON_NCT75 temperature;
 
 void setup() {
   while(!Serial) {}
-  
+
   Serial.begin(9600);
 
   Wire.begin();
@@ -42,8 +42,8 @@ void loop() {
   The datasheet instead lists the typical conversion time to be 48.5 ms.
   As it doesn't list the max conversion time, we wait ~2x the typical time
   */
-  delay(100); 
-  
+  delay(100);
+
   Serial.print("Temperature is: ");
   Serial.print(temperature.readTemperatureC());
   Serial.println(" C!");

--- a/src/Temperature_LM75_Derived.h
+++ b/src/Temperature_LM75_Derived.h
@@ -274,10 +274,10 @@ class OnSemi_NCTx75 : public Generic_LM75_12Bit {
   };
   
   public:
-  OnSemi_OneShot(TwoWire *bus = &Wire, uint8_t i2c_address = DEFAULT_I2C_ADDRESS)
+  OnSemi_NCTx75(TwoWire *bus = &Wire, uint8_t i2c_address = DEFAULT_I2C_ADDRESS)
     : Generic_LM75_12Bit(bus, i2c_address) { };
 
-  OnSemi_OneShot(uint8_t i2c_address)
+  OnSemi_NCTx75(uint8_t i2c_address)
     : Generic_LM75_12Bit(&Wire, i2c_address) { };
   
   void enableOneShotMode() {

--- a/src/Temperature_LM75_Derived.h
+++ b/src/Temperature_LM75_Derived.h
@@ -265,7 +265,7 @@ public:
     : Generic_LM75_9_to_12Bit_Compatible(&Wire, i2c_address, &Generic_LM75_12Bit_Attributes) { };
 };
 
-class OnSemi_OneShot : public Generic_LM75_12Bit {
+class OnSemi_NCTx75 : public Generic_LM75_12Bit {
   private:
 
   enum ConfigurationBits {
@@ -393,8 +393,8 @@ public:
 #define NXP_LM75B               Generic_LM75_11Bit
 #define NXP_PCT2075             Generic_LM75_11Bit
 #define NXP_SE95                Generic_LM75_12Bit
-#define ON_NCT75                Generic_LM75_12Bit
-#define ON_NCT_OS               OnSemi_OneShot
+#define ON_NCT75                OnSemi_NCTx75
+#define ON_NCT375               OnSemi_NCTx75
 #define ST_STCN75               Generic_LM75
 #define ST_STLM75               Generic_LM75
 #define ST_STTS75               Generic_LM75_9_to_12Bit_OneShot

--- a/src/Temperature_LM75_Derived.h
+++ b/src/Temperature_LM75_Derived.h
@@ -265,6 +265,36 @@ public:
     : Generic_LM75_9_to_12Bit_Compatible(&Wire, i2c_address, &Generic_LM75_12Bit_Attributes) { };
 };
 
+class OnSemi_OneShot : public Generic_LM75_12Bit {
+  private:
+
+  enum ConfigurationBits {
+    OneShot           = 5, // Mask 0x20, length 1 bit
+    Shutdown          = 0  // Mask 0x01, length 1 bit
+  };
+  
+  public:
+  OnSemi_OneShot(TwoWire *bus = &Wire, uint8_t i2c_address = DEFAULT_I2C_ADDRESS)
+    : Generic_LM75_12Bit(bus, i2c_address) { };
+
+  OnSemi_OneShot(uint8_t i2c_address)
+    : Generic_LM75_12Bit(&Wire, i2c_address) { };
+  
+  void enableOneShotMode() {
+    setConfigurationBits(bit(ConfigurationBits::OneShot));
+    clearConfigurationBits(bit(ConfigurationBits::Shutdown));
+  }
+
+  void startOneShotConversion() {
+    bus->beginTransmission(i2c_address);
+
+    bus->write(0x04); // OneShot trigger register
+    bus->write(1); // Writing anything triggers the oneshot
+
+    bus->endTransmission();
+  }
+
+};
 
 class Generic_LM75_9_to_12Bit_OneShot_Compatible : public Generic_LM75_9_to_12Bit_Compatible {
 private:
@@ -364,6 +394,7 @@ public:
 #define NXP_PCT2075             Generic_LM75_11Bit
 #define NXP_SE95                Generic_LM75_12Bit
 #define ON_NCT75                Generic_LM75_12Bit
+#define ON_NCT_OS               OnSemi_OneShot
 #define ST_STCN75               Generic_LM75
 #define ST_STLM75               Generic_LM75
 #define ST_STTS75               Generic_LM75_9_to_12Bit_OneShot


### PR DESCRIPTION
Hi there, and thanks for a neat library :)

I found myself with a box of NCT75 chips from OnSemi, and was interested in using the one-shot feature, as they're for a batter powered project that'll spend most of its time sleeping.

As the one-shot implementation is onsemi specific, I added a class for it. The onsemi implementation is fairly simple. When setting config bit 5, the chip immediately shuts-down, and is now ready for a oneshot trigger. That trigger is writing anything to register `0x04` 

It is unclear if the shutdown-bit overwrites this behavior, however it does so in other, similar chips, so to be safe this is set to 0.

There's no way to check if a conversion is done, so the datasheet spec of 48.5 ms typical one-shot conversion time is doubled to hopefully be a sensible "worst case" time.

The sensors doc is updated to reflect this support, and a specific example is added.  