### PR TITLE
Added delay(0) to all idle loops

### DIFF
--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -10,7 +10,7 @@ in Celcius every 250ms. Any LM75-derived temperature should work.
 Generic_LM75 temperature;
 
 void setup() {
-  while(!Serial) {}
+  while(!Serial) {delay(0);}
   
   Serial.begin(9600);
 

--- a/examples/MultipleSensors/MultipleSensors.ino
+++ b/examples/MultipleSensors/MultipleSensors.ino
@@ -12,7 +12,7 @@ Generic_LM75 temperature1(0x48);
 Generic_LM75 temperature2(0x49);
 
 void setup() {
-  while(!Serial) {}
+  while(!Serial) {delay(0);}
   
   Serial.begin(9600);
 

--- a/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
+++ b/examples/OnSemiOneShotMode/OnSemiOneShotMode.ino
@@ -22,7 +22,7 @@ from an otherwise shutdown sensor. This can be used for two purposes:
 ON_NCT75 temperature;
 
 void setup() {
-  while(!Serial) {}
+  while(!Serial) {delay(0);}
 
   Serial.begin(9600);
 

--- a/examples/ShutdownModeOneShot/ShutdownModeOneShot.ino
+++ b/examples/ShutdownModeOneShot/ShutdownModeOneShot.ino
@@ -19,7 +19,7 @@ from an otherwise shutdown sensor. This can be used for two purposes:
 Generic_LM75_9_to_12Bit_OneShot temperature;
 
 void setup() {
-  while(!Serial) {}
+  while(!Serial) {delay(0);}
   
   Serial.begin(9600);
 

--- a/examples/Thermostat/Thermostat.ino
+++ b/examples/Thermostat/Thermostat.ino
@@ -34,7 +34,7 @@ an interrupt upon the sensor crossing a the T_high -or- T_low thresholds
 Generic_LM75 temperature;
 
 void setup() {
-  while(!Serial) {}
+  while(!Serial) {delay(0);}
 
   Serial.begin(9600);
 


### PR DESCRIPTION
Stumbled on another tiny issue when playing with this on my ESPs (eventual target device)

The examples have the usual idle loop waiting for CDC based serial ports to be available, however on some boards (like the ESPs) this won't return true before begin has been called. with nothing else that'd just hang forever, however hanging "forever" on ESPs also trigger a watchdog reset, as there's an RTOS running in the background managing the network stack and such.

As such, a delay(0) has been added to the idle loop, to allow the RTOS to context switch and handle stuff, and begin has been moved before the idle loop.  This is also in-line with current Arduino examples :) 